### PR TITLE
update dependencies versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,36 @@
+{
+  "name": "testx-html-reporter",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "hat": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/hat/-/hat-0.0.3.tgz",
+      "integrity": "sha1-uwFKnmSzeIrtgAWRdBPU/z1QLYo="
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "string.prototype.startswith": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.startswith/-/string.prototype.startswith-0.2.0.tgz",
+      "integrity": "sha1-2miYLjU6TprEpDtFCiBF0cRFrns="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   },
   "dependencies": {
     "hat": "0.0.3",
-    "lodash": "^3.0.0",
-    "mkdirp": "^0.5.0",
+    "lodash": "^4.17.15",
+    "mkdirp": "^0.5.1",
     "string.prototype.startswith": "^0.2.0"
   }
 }


### PR DESCRIPTION
Update dependencies versions because of the security alert [Prototype Pollution](https://npmjs.com/advisories/1065).